### PR TITLE
Make sure the scrapyd logs directory exists

### DIFF
--- a/tasks/scrapyd.yml
+++ b/tasks/scrapyd.yml
@@ -29,6 +29,10 @@
   pip: name={{item}} executable={{scrapyd_home}}/env/bin/pip
   with_items: scrapyd_extensions
 
+- name: Prepare log directory
+  file: state=directory path={{scrapyd_logfile_dir}}
+  when: scrapyd_logfile_dir is defined
+
 - name: Configure scrapy local settings
   template: src=local_settings.py.j2 dest={{scrapyd_home}}/local_settings.py owner={{scrapyd_user}}
   when: scrapyd_scrapy_settings


### PR DESCRIPTION
Fix error if the `scrapyd_logfile_dir` variable is set to a directory that does not exist.