### PR TITLE
Remove pip executable argument as it's now mutually exclusive with virtualenv argument

### DIFF
--- a/tasks/scrapyd.yml
+++ b/tasks/scrapyd.yml
@@ -21,12 +21,12 @@
   sudo_user: "{{scrapyd_user}}"
 
 - name: Install Scrapyd
-  pip: name=scrapyd executable={{scrapyd_home}}/env/bin/pip version={{scrapyd_version}}  virtualenv="{{scrapyd_home}}"/env
+  pip: name=scrapyd version={{scrapyd_version}} virtualenv={{scrapyd_home}}/env
   sudo: yes
   sudo_user: "{{scrapyd_user}}"
 
 - name: Install extensions
-  pip: name={{item}} executable={{scrapyd_home}}/env/bin/pip
+  pip: name={{item}} virtualenv={{scrapyd_home}}/env
   with_items: scrapyd_extensions
 
 - name: Configure scrapy local settings


### PR DESCRIPTION
See commit: https://github.com/ansible/ansible-modules-core/pull/3074/commits/24c6b269c93464152d1bb4b58ccbbff2b1425867