### PR TITLE
Upgrade setuptools before installing scrapyd

### DIFF
--- a/tasks/scrapyd.yml
+++ b/tasks/scrapyd.yml
@@ -20,6 +20,11 @@
   sudo: yes
   sudo_user: "{{scrapyd_user}}"
 
+- name: Upgrade setuptools
+  pip: name=setuptools virtualenv={{scrapyd_home}}/env extra_args=--upgrade
+  sudo: yes
+  sudo_user: "{{scrapyd_user}}"
+
 - name: Install Scrapyd
   pip: name=scrapyd executable={{scrapyd_home}}/env/bin/pip version={{scrapyd_version}}  virtualenv="{{scrapyd_home}}"/env
   sudo: yes


### PR DESCRIPTION
Had a VersionConflict error when installing Scrapyd on Ubuntu 14.04. Upgrading setuptools solved it. 